### PR TITLE
Switch to SwiftParser

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "0b6c22b97f8e9320bca62e82cdbee601cf37ad3f",
-        "version" : "0.50600.1"
+        "branch" : "main",
+        "revision" : "a2af7da5a687681621e8387683e03b20fe2c3aaf"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,13 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftHighlighting",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6),
+        .macCatalyst(.v13),
+    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
@@ -13,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-         .package(url: "https://github.com/apple/swift-syntax", exact: "0.50600.1"),
+         .package(url: "https://github.com/apple/swift-syntax", branch: "main"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -21,8 +28,7 @@ let package = Package(
         .target(
             name: "SwiftHighlighting",
             dependencies: [
-                .product(name: "SwiftSyntax", package: "swift-syntax"),
-                .product(name: "SwiftSyntaxParser", package: "swift-syntax"),
+                .product(name: "SwiftParser", package: "swift-syntax"),
             ]),
         .testTarget(
             name: "SwiftHighlightingTests",

--- a/Sources/SwiftHighlighting/SwiftHighlighting.swift
+++ b/Sources/SwiftHighlighting/SwiftHighlighting.swift
@@ -8,7 +8,6 @@
 import AppKit
 import SwiftParser
 import SwiftSyntax
-import SwiftSyntaxParser
 
 extension NSAttributedString {
     static public func highlightSwift(_ input: String, stylesheet: Stylesheet = .xcodeDefault, attributes: [NSAttributedString.Key: Any] = [:]) -> NSAttributedString {

--- a/Sources/SwiftHighlighting/SwiftHighlighting.swift
+++ b/Sources/SwiftHighlighting/SwiftHighlighting.swift
@@ -5,12 +5,10 @@
 //  Created by Chris Eidhof on 25.03.21.
 //
 
-import Foundation
+import AppKit
+import SwiftParser
 import SwiftSyntax
 import SwiftSyntaxParser
-import Foundation
-import AppKit
-
 
 extension NSAttributedString {
     static public func highlightSwift(_ input: String, stylesheet: Stylesheet = .xcodeDefault, attributes: [NSAttributedString.Key: Any] = [:]) -> NSAttributedString {
@@ -89,7 +87,7 @@ class SwiftHighlighter {
     }
     
     private func _highlight(_ code: String) throws -> Result {
-        let sourceFile = try SyntaxParser.parse(source: code)
+        let sourceFile = try Parser.parse(source: code)
         let highlighter = SwiftHighlighterRewriter()
         _ = highlighter.visit(sourceFile)
         

--- a/Tests/SwiftHighlightingTests/SwiftHighlightingTests.swift
+++ b/Tests/SwiftHighlightingTests/SwiftHighlightingTests.swift
@@ -2,4 +2,31 @@ import XCTest
 @testable import SwiftHighlighting
 
 final class SwiftHighlightingTests: XCTestCase {
+    func testStruct() throws {
+        let input = """
+            struct Foo {
+                // Comment
+                let bar = true
+                var str = ("hello", 42)
+            }
+            """
+
+        let result = try SwiftHighlighter.shared.highlight([input])[0]
+
+        let testRanges: [(fragment: String, kind: SwiftHighlighting.TokenKind)] = [
+            (fragment: "struct ", kind: .keyword),
+            (fragment: "// Comment", kind: .comment),
+            (fragment: "let ", kind: .keyword),
+            (fragment: "var ", kind: .keyword),
+            (fragment: "true", kind: .keyword),
+            (fragment: "hello", kind: .string),
+            (fragment: "42", kind: .number),
+        ]
+
+        for range in testRanges {
+            XCTAssertTrue(result.contains(where: { (r, k) in
+                r == input.range(of: range.fragment) && k == range.kind
+            }), "Should contain {\(range.fragment)} as a \(range.kind)")
+        }
+    }
 }


### PR DESCRIPTION
- This requires us to use `main` branch instead of pinning the dependency to a release.
- The swift-parser package requires macOS 10.15.