### PR TITLE
Highlight all keywords

### DIFF
--- a/Sources/SwiftHighlighting/SwiftHighlighting.swift
+++ b/Sources/SwiftHighlighting/SwiftHighlighting.swift
@@ -185,7 +185,7 @@ class SwiftHighlighterRewriter: SyntaxRewriter {
             kind = .string
         case .integerLiteral, .floatingLiteral:
             kind = .number
-        case _ where token.tokenKind.isLexerClassifiedKeyword:
+        case _ where token.tokenKind.isLexerClassifiedKeyword, .keyword:
             kind = .keyword
         default:
             kind = nil

--- a/Tests/SwiftHighlightingTests/SwiftHighlightingTests.swift
+++ b/Tests/SwiftHighlightingTests/SwiftHighlightingTests.swift
@@ -30,6 +30,32 @@ final class SwiftHighlightingTests: XCTestCase {
         }
     }
 
+    func testClass() throws {
+        let input = """
+            final class Foo: UIViewController {
+                override func viewDidLoad() {
+                    super.viewDidLoad()
+                }
+            }
+            """
+
+        let result = try SwiftHighlighter.shared.highlight([input])[0]
+
+        let testRanges: [(fragment: String, kind: SwiftHighlighting.TokenKind)] = [
+            (fragment: "final ", kind: .keyword),
+            (fragment: "class ", kind: .keyword),
+            (fragment: "override ", kind: .keyword),
+            (fragment: "func ", kind: .keyword),
+            (fragment: "super", kind: .keyword),
+        ]
+
+        for range in testRanges {
+            XCTAssertTrue(result.contains(where: { (r, k) in
+                r == input.range(of: range.fragment) && k == range.kind
+            }), "Should contain {\(range.fragment)} as a \(range.kind)")
+        }
+    }
+
     func testRegression0() throws {
         let input = """
         HStack {


### PR DESCRIPTION
Highlight all keywords, not just `isLexerClassified` ones. The new test case shows that it previously did not highlight `override` and `super`.

The whole list of keywords it matches is [here](https://github.com/apple/swift-syntax/blob/main/Sources/SwiftSyntax/generated/Keyword.swift).